### PR TITLE
Rename "CI workflow" to "test workflow"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -11,22 +11,22 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-    name: Build
+  required:
+    name: ubuntu / stable
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Build
-        run: cargo build --verbose
+      - name: Compile tests
+        run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --locked
 
-  ci-success:
-    name: CI workflow
+  test-success:
+    name: Test workflow
     if: github.event.pusher.name == 'bors[bot]' && success()
     runs-on: ubuntu-latest
     needs:
-      - build
+      - required
     steps:
-      - name: CI workflow succeeded
+      - name: Test workflow succeeded
         run: exit 0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RustOps Blueprint
 
-[![CI Status](https://github.com/elasticdog/rustops-blueprint/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/elasticdog/rustops-blueprint/actions/workflows/ci.yml?query=branch%3Amain)
+[![Test Status](https://github.com/elasticdog/rustops-blueprint/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/elasticdog/rustops-blueprint/actions/workflows/test.yml?query=branch%3Amain)
 
 ## License
 

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 #required_approvals = 1
-status = ["CI workflow"]
+status = ["Test workflow"]
 up_to_date_approvals = true


### PR DESCRIPTION
I think this is a bit more clear, and will allow for other logical workflows like "Check", "Release", etc. Trying it on for size.

See:
- https://youtu.be/xUH-4y92jPg