### PR TITLE
Run CI directly on PRs but not on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: test
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+  push:
+    branches:
       - staging
       - trying
 


### PR DESCRIPTION
The main branch is essentially a duplicated test run since bors will test staging and fast forward main when it was successful. This might lose some green checkmarks on the commit list though, but I'm not sure how much that will actually matter if it's only the merge commits that won't have a status.