### PR TITLE
Always run the workflow status summary job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,12 +23,13 @@ jobs:
       - name: Run tests
         run: cargo test --locked
 
-  test-success:
-    name: test workflow
-    if: github.event.pusher.name == 'bors[bot]' && success()
+  workflow_status:
+    name: test workflow status
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - required
     steps:
-      - name: Test workflow succeeded
-        run: exit 0
+      - name: Check `ubuntu / stable` job status
+        run: |
+          [[ "${{ needs.required.result }}" = "success" ]] && exit 0 || exit 1

--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,3 @@
 #required_approvals = 1
-status = ["test workflow"]
+status = ["test workflow status"]
 up_to_date_approvals = true


### PR DESCRIPTION
This is used by bors to help it determine the overall status once job structure gains is a bit more complex. I've alsofound it confusing to see it skipped on the PR tests. I know some of the rust-lang project define two separate jobs with the same `name:`, but I that's a bit ugly and still has one that is always skipped. I think this will ensure that it reports success/failure as we want it to, and I don't think we need to check that it was bors that did the pushing, but we'll find out.