### PR TITLE
Enable dependabot security and version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   CI: 1
-  RUSTFLAGS: "-D warnings"
   RUST_BACKTRACE: 1
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   required:


### PR DESCRIPTION
Note that security updates are already configured within the repo settings unless you want to specifically ignore something.

See:
- https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/about-dependabot-security-updates
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates