### PR TITLE
Automatically cancel running PR tests if a new push occurs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
       - staging
       - trying
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This should leave all `main` branch tests running to completion. I'll have to test and make sure this works with bors as expected.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
- https://docs.github.com/en/actions/learn-github-actions/contexts#github-context