### PR TITLE
Configure crates to inherit workspace keys from package table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,11 @@
 [workspace]
 members = ["crates/*"]
 
+[workspace.package]
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [profile.dev]
 # Disabling debug info speeds up builds a bunch,
 # and we don't rely on it for debugging that much.

--- a/crates/mybin/Cargo.toml
+++ b/crates/mybin/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mybin"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/mylib/Cargo.toml
+++ b/crates/mylib/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "mylib"
-version = "0.1.0"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This allows us to DRY up some of these definitions so they're defined within the top-level virtual manifest.

See:
- https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table