### PR TITLE
Run tests on the main branch to establish caches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,7 @@ on:
       - main
   push:
     branches:
+      - main
       - staging
       - trying
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - main
   push:
     branches:
+      - main
       - staging
       - trying
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# RustOps Blueprint
+# RustOps Blueprint &emsp; [![CI Status]][actions]
 
-[![Test Status](https://github.com/elasticdog/rustops-blueprint/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/elasticdog/rustops-blueprint/actions/workflows/test.yml?query=branch%3Amain)
+[CI Status]:
+  https://img.shields.io/github/checks-status/elasticdog/rustops-blueprint/main?label=CI&logo=github
+[actions]:
+  https://github.com/elasticdog/rustops-blueprint/actions?query=branch%3Amain
+
+**RustOps Blueprint is code repository template for a polished Rust development
+experience.**
+
+---
 
 ## License
 
-Licensed under either of
+RustOps Blueprint is distributed under the terms of both the Apache License
+(Version 2.0) and the MIT license.
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
-at your option.
+See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 
 ## Contribution
 


### PR DESCRIPTION
While this may be technically redundant since staging is what essentially becomes main after a successful build, caches can be shared on PRs from the target branch (main), so we'll want to ensure that we build there. It also makes sense that we'll want our CI status badge to point to these builds to prevent confusion.