### PR TITLE
Use cargo-nextest for running tests in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@7522ae03ca435a0ad1001ca93d6cd7cb8e81bd2f
+        with:
+          tool: cargo-nextest
+
       - name: Cache dependencies
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
 
@@ -39,7 +44,7 @@ jobs:
         run: cargo test --locked --no-run
 
       - name: Run tests
-        run: cargo test --locked
+        run: cargo nextest run --locked
 
   workflow_status:
     name: test workflow status

--- a/README.md
+++ b/README.md
@@ -5,15 +5,14 @@
 [actions]:
   https://github.com/elasticdog/rustops-blueprint/actions?query=branch%3Amain
 
-**RustOps Blueprint is code repository template for a polished Rust development
-experience.**
+**A code repository template for a polished Rust development experience.**
 
 ---
 
 ## License
 
 RustOps Blueprint is distributed under the terms of both the Apache License
-(Version 2.0) and the MIT license.
+(Version 2.0) and the MIT License.
 
 See [LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for details.
 


### PR DESCRIPTION
This is useful for a number of reasons, but being able to see the timing information for individual tests can be useful feedback, and an incentive to improve execution time. There are a handful of other features designed specifically to address pain points of testing in CI.

See:
- https://nexte.st/index.html
- https://matklad.github.io/2021/05/31/how-to-test.html#Make-Tests-Fast