### PR TITLE
Deploy package docs to GitHub Pages

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  CI: 1
 
 jobs:
   format:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+
+  # Allow manually running this workflow.
+  workflow_dispatch:
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-
+# progress and latest queued. However, do NOT cancel in-progress runs as we want
+# to allow these production deployments to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build / stable
+    env:
+      CARGO_TERM_COLOR: always
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Install stable Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
+
+      - name: Build docs
+        run: cargo doc --no-deps
+
+      - name: Upload github-pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: target/doc
+
+  deploy:
+    name: deploy / github-pages
+    needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.output.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ concurrency:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
-  CI: 1
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
 


### PR DESCRIPTION
This uses the newer beta method of using GitHub Actions to directly deploy to an environment, rather than the "classic" method of pushing the docs to a dedicated branch in the repository.

See:
- https://docs.github.com/en/pages
- https://github.com/actions/upload-pages-artifact
- https://github.com/actions/deploy-pages
- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow