### PR TITLE
Enable generation of the top-level docs index page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,13 +24,12 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Install stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache dependencies
-        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
+      - name: Install nightly Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Build docs
+        env:
+          RUSTDOCFLAGS: --enable-index-page -Z unstable-options
         run: cargo doc --no-deps
 
       - name: Upload github-pages artifact


### PR DESCRIPTION
The feature to build this index page is still unstable, so we have to use a nightly toolchain, which doesn't make sense to cache.

Running `cargo doc` by default won't generate this top-level index, and running `cargo rustdocs` with custom options will only build a single package at a time, but we can pass flags to all rustdoc processes spawned by Cargo via an environment variable.

See:
- https://doc.rust-lang.org/cargo/reference/unstable.html
- https://github.com/rust-lang/cargo/issues/8229
- https://github.com/rust-lang/rust/issues/73185