### PR TITLE
Allow deploy GITHUB_TOKEN write access to the contents scope

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,6 @@ jobs:
     name: deploy / github-pages
     needs: build
     permissions:
-      contents: read
       pages: write
       id-token: write
     environment:


### PR DESCRIPTION
There was a mismatch between the documentation and some of the examples for how these deployments work. The default access for a GITHUB_TOKEN normally includes read/write access to the "contents" scope, but the example starter-workflows made it more restrictive. I'm seeing a failure of the `actions/deploy-pages` step to set the expected `output.page_url`, and I'm guessing it has to do with this restriction.

This is the warning annotation on the workflow run:

> Environment URL '' is not a valid http(s) URL, so it will not be shown as a link in the workflow graph.

See:
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
- https://github.com/actions/starter-workflows/blob/main/pages/static.yml
- https://github.com/actions/deploy-pages