### PR TITLE
Ensure packages and dependencies compile on the MSRV

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,6 +54,29 @@ jobs:
       - name: Check lints
         run: cargo clippy -- -D warnings
 
+  # Minimum Supported Rust Version
+  msrv:
+    name: msrv / compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+
+      - name: Get MSRV from package metadata
+        id: msrv
+        run: awk -F '"' '/rust-version/{ print "version=" $2 }' Cargo.toml >> $GITHUB_OUTPUT
+
+      - name: Install ${{ steps.msrv.outputs.version }} Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
+
+      - name: Check packages and dependencies for errors
+        run: cargo check --locked
+
   workflow_status:
     name: check workflow status
     if: always()
@@ -61,6 +84,7 @@ jobs:
     needs:
       - format
       - lint
+      - msrv
     steps:
       - name: Check `stable / format` job status
         run: |
@@ -68,3 +92,6 @@ jobs:
       - name: Check `stable / lint` job status
         run: |
           [[ "${{ needs.lint.result }}" = "success" ]] && exit 0 || exit 1
+      - name: Check `msrv / compile` job status
+        run: |
+          [[ "${{ needs.msrv.result }}" = "success" ]] && exit 0 || exit 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["crates/*"]
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.64"
 license = "MIT OR Apache-2.0"
 
 [profile.dev]

--- a/crates/mybin/Cargo.toml
+++ b/crates/mybin/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mybin"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/mylib/Cargo.toml
+++ b/crates/mylib/Cargo.toml
@@ -2,6 +2,7 @@
 name = "mylib"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The Minimum Supported Rust Version (MSRV) for the 2021 edition of Rust is 1.56, although the ability to have packages inherit settings from the workspace wasn't added until Cargo 1.64. Ideally we'd **verify** compatibility via something like `cargo-msrv`, but this is a decent smoke test for starters.

See:
- https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field
- https://github.com/rust-lang/cargo/blob/master/CHANGELOG.md#cargo-164-2022-09-22
- https://github.com/rust-lang/api-guidelines/discussions/231
- https://foresterre.github.io/cargo-msrv/