### PR TITLE
Define a bors workflow to DRY up actions files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,12 +8,39 @@ name: check
       - main
       - staging
       - trying
+env:
+  CARGO_TERM_COLOR: always
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-env:
-  CARGO_TERM_COLOR: always
 jobs:
+  cue:
+    name: cue / vet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Install CUE v0.5.0
+        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
+        with:
+          version: v0.5.0
+      - name: Validate CUE files
+        working-directory: .github/workflows
+        run: cue vet -c
+      - name: Regenerate YAML from CUE
+        working-directory: .github/workflows
+        run: cue cmd genworkflows
+      - name: Check if CUE and YAML are in sync
+        run: |-
+          if git diff --quiet HEAD --; then
+              echo 'CUE and YAML files are in sync; the working tree is clean.'
+          else
+              git diff --color --patch-with-stat HEAD --
+              echo "***"
+              echo 'Error: CUE and YAML files are out of sync; the working tree is dirty.'
+              echo 'Run `cue cmd genworkflows` locally to regenerate the YAML from CUE.'
+              exit 1
+          fi
   format:
     name: stable / format
     runs-on: ubuntu-latest
@@ -61,48 +88,21 @@ jobs:
         uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f
       - name: Check packages and dependencies for errors
         run: cargo check --locked
-  cue:
-    name: cue / vet
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Install CUE v0.5.0
-        uses: cue-lang/setup-cue@0be332bb74c8a2f07821389447ba3163e2da3bfb
-        with:
-          version: v0.5.0
-      - name: Validate CUE files
-        working-directory: .github/workflows
-        run: cue vet -c
-      - name: Regenerate YAML from CUE
-        working-directory: .github/workflows
-        run: cue cmd genworkflows
-      - name: Check if CUE and YAML are in sync
-        run: |-
-          if git diff --quiet HEAD --; then
-              echo 'CUE and YAML files are in sync; the working tree is clean.'
-          else
-              git diff --color --patch-with-stat HEAD --
-              echo "***"
-              echo 'Error: CUE and YAML files are out of sync; the working tree is dirty.'
-              echo 'Run `cue cmd genworkflows` locally to regenerate the YAML from CUE.'
-              exit 1
-          fi
   workflow_status:
     name: check workflow status
-    if: always()
     needs:
+      - cue
       - format
       - lint
       - msrv
-      - cue
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check `stable / format` job status
-        run: '[[ "${{ needs.format.result }}" = "success" ]] && exit 0 || exit 1'
-      - name: Check `stable / lint` job status
-        run: '[[ "${{ needs.lint.result }}" = "success" ]] && exit 0 || exit 1'
-      - name: Check `msrv / compile` job status
-        run: '[[ "${{ needs.msrv.result }}" = "success" ]] && exit 0 || exit 1'
-      - name: Check `cue / vet` job status
+      - name: 'Check status of job_id: cue'
         run: '[[ "${{ needs.cue.result }}" = "success" ]] && exit 0 || exit 1'
+      - name: 'Check status of job_id: format'
+        run: '[[ "${{ needs.format.result }}" = "success" ]] && exit 0 || exit 1'
+      - name: 'Check status of job_id: lint'
+        run: '[[ "${{ needs.lint.result }}" = "success" ]] && exit 0 || exit 1'
+      - name: 'Check status of job_id: msrv'
+        run: '[[ "${{ needs.msrv.result }}" = "success" ]] && exit 0 || exit 1'

--- a/.github/workflows/test.cue
+++ b/.github/workflows/test.cue
@@ -1,6 +1,6 @@
 package workflows
 
-test: {
+test: _#borsWorkflow & {
 	name: "test"
 
 	on: {
@@ -44,19 +44,7 @@ test: {
 		}
 
 		workflow_status: {
-			name: "test workflow status"
-			if:   "always()"
-			needs: [
-				"required",
-			]
-			steps: [
-				{
-					name: "Check `linux / stable` job status"
-					run: """
-						[[ \"${{ needs.required.result }}\" = \"success\" ]] && exit 0 || exit 1
-						"""
-				},
-			]
+			needs: ["required"]
 		}
 	}
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,14 @@ name: test
       - main
       - staging
       - trying
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   required:
     name: linux / stable
@@ -39,10 +39,10 @@ jobs:
         run: cargo nextest run --locked
   workflow_status:
     name: test workflow status
-    if: always()
     needs:
       - required
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Check `linux / stable` job status
+      - name: 'Check status of job_id: required'
         run: '[[ "${{ needs.required.result }}" = "success" ]] && exit 0 || exit 1'


### PR DESCRIPTION
This now generates all of the workflow status jobs, as long as we maintain a list of the job IDs that we want to require for bors to check before approving each workflow.