### PR TITLE
Use explicit "runs-on" for each job

### DIFF
--- a/.github/workflows/github-actions.cue
+++ b/.github/workflows/github-actions.cue
@@ -15,9 +15,10 @@ githubActions: _#borsWorkflow & {
 
 	env: CARGO_TERM_COLOR: "always"
 
-	jobs: _#defaultJobs & {
+	jobs: {
 		cueVet: {
-			name: "cue / vet"
+			name:      "cue / vet"
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installCue,
@@ -32,6 +33,7 @@ githubActions: _#borsWorkflow & {
 		cueFormat: {
 			name: "cue / format"
 			needs: ["cueVet"]
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installCue,
@@ -60,6 +62,7 @@ githubActions: _#borsWorkflow & {
 		cueSynced: {
 			name: "cue / synced"
 			needs: ["cueVet"]
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installCue,

--- a/.github/workflows/github-pages.cue
+++ b/.github/workflows/github-pages.cue
@@ -18,9 +18,10 @@ githubPages: {
 		"cancel-in-progress": false
 	}
 
-	jobs: _#defaultJobs & {
+	jobs: {
 		build: {
-			name: "build / stable"
+			name:      "build / stable"
+			"runs-on": defaultRunner
 			env: CARGO_TERM_COLOR: "always"
 			steps: [
 				_#checkoutCode,
@@ -45,6 +46,7 @@ githubPages: {
 				"id-token": "write"
 				pages:      "write"
 			}
+			"runs-on": defaultRunner
 			environment: {
 				name: "github-pages"
 				url:  "${{ steps.deployment.outputs.page_url }}"

--- a/.github/workflows/rust.cue
+++ b/.github/workflows/rust.cue
@@ -20,9 +20,10 @@ rust: _#borsWorkflow & {
 		RUSTFLAGS:         "-D warnings"
 	}
 
-	jobs: _#defaultJobs & {
+	jobs: {
 		check: {
-			name: "check"
+			name:      "check"
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -35,7 +36,8 @@ rust: _#borsWorkflow & {
 		}
 
 		format: {
-			name: "format"
+			name:      "format"
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "clippy,rustfmt"},
@@ -48,7 +50,8 @@ rust: _#borsWorkflow & {
 		}
 
 		lint: {
-			name: "lint"
+			name:      "lint"
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installRust & {with: components: "clippy,rustfmt"},
@@ -63,6 +66,7 @@ rust: _#borsWorkflow & {
 		testStable: {
 			name: "test / stable"
 			needs: ["check", "format", "lint"]
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				_#installRust,
@@ -87,6 +91,7 @@ rust: _#borsWorkflow & {
 		checkMsrv: {
 			name: "check / msrv"
 			needs: ["check", "format", "lint"]
+			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
 				{

--- a/.github/workflows/workflows.cue
+++ b/.github/workflows/workflows.cue
@@ -39,8 +39,9 @@ _#borsWorkflow: github.#Workflow & {
 		"bors": _#job & {
 			name: "bors needs met for \(workflowName)"
 			// TODO: ensure needs can't be empty
-			needs: github.#Workflow.#jobNeeds
-			if:    "always()"
+			needs:     github.#Workflow.#jobNeeds
+			"runs-on": defaultRunner
+			if:        "always()"
 			steps: [
 				for jobId in needs {
 					name: "Check status of job_id: \(jobId)"
@@ -55,10 +56,6 @@ _#borsWorkflow: github.#Workflow & {
 // Declare definitions for sub-schemas
 _#job:  (github.#Workflow.jobs & {x: _}).x
 _#step: ((_#job & {steps:            _}).steps & [_])[0]
-
-_#defaultJobs: github.#Workflow.jobs & {
-	[string]: "runs-on": defaultRunner
-}
 
 _#checkoutCode: _#step & {
 	name: "Checkout source code"


### PR DESCRIPTION
I couldn't figure out how to deduplicate this when we need the ability to override in certain cases like matrix jobs. At least we can use the defaultRunner value, and I'll keep looking into other possibilities.