### PR TITLE
Do not rebuild github-pages if only Actions files change

### DIFF
--- a/.github/workflows/github-pages.cue
+++ b/.github/workflows/github-pages.cue
@@ -4,7 +4,13 @@ githubPages: {
 	name: "github-pages"
 
 	on: {
-		push: branches: [defaultBranch]
+		push: {
+			branches: [defaultBranch]
+			paths: [
+				"!.github/**",
+				".github/workflows/github-pages.yml",
+			]
+		}
 
 		// Allow manually running this workflow.
 		workflow_dispatch: null

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -3,6 +3,9 @@ name: github-pages
   push:
     branches:
       - main
+    paths:
+      - '!.github/**'
+      - .github/workflows/github-pages.yml
   workflow_dispatch: null
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The exception is if its own workflow file changes, then it should be triggered.

See:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet