### PR TITLE
Abstract out the changes job so it can be shared

### DIFF
--- a/.github/workflows/github-actions.cue
+++ b/.github/workflows/github-actions.cue
@@ -6,24 +6,7 @@ githubActions: _#borsWorkflow & {
 	env: CARGO_TERM_COLOR: "always"
 
 	jobs: {
-		changes: {
-			name:      "detect repo changes"
-			"runs-on": defaultRunner
-			permissions: "pull-requests": "read"
-			outputs: {
-				"github-actions": "${{ steps.filter.outputs.github-actions }}"
-			}
-			steps: [
-				_#checkoutCode & {with: "fetch-depth": 20},
-				_#filterChanges & {
-					with: filters: """
-						github-actions:
-						  - '.github/**/*.cue'
-						  - '.github/**/*.yml'
-						"""
-				},
-			]
-		}
+		changes: _#changes
 
 		cueVet: {
 			name: "cue / vet"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -21,19 +21,23 @@ jobs:
       pull-requests: read
     outputs:
       github-actions: ${{ steps.filter.outputs.github-actions }}
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
         with:
           fetch-depth: 20
-      - id: filter
-        name: Filter changed repository files
+      - name: Filter changed repository files
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
+        id: filter
         with:
           filters: |-
             github-actions:
               - '.github/**/*.cue'
               - '.github/**/*.yml'
+            rust:
+              - '**/*.rs'
+              - '**/Cargo.*'
   cueVet:
     name: cue / vet
     needs:

--- a/.github/workflows/workflows.cue
+++ b/.github/workflows/workflows.cue
@@ -77,6 +77,32 @@ _#borsWorkflow: _#pullRequestWorkflow & {
 _#job:  (github.#Workflow.jobs & {x: _}).x
 _#step: ((_#job & {steps:            _}).steps & [_])[0]
 
+_#changes: _#job & {
+	name:      "detect repo changes"
+	"runs-on": defaultRunner
+	permissions: "pull-requests": "read"
+	outputs: {
+		"github-actions": "${{ steps.filter.outputs.github-actions }}"
+		"rust":           "${{ steps.filter.outputs.rust }}"
+	}
+	steps: [
+		_#checkoutCode & {with: "fetch-depth": 20},
+		{
+			name: "Filter changed repository files"
+			uses: "dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50"
+			id:   "filter"
+			with: filters: """
+				github-actions:
+				  - '.github/**/*.cue'
+				  - '.github/**/*.yml'
+				rust:
+				  - '**/*.rs'
+				  - '**/Cargo.*'
+				"""
+		},
+	]
+}
+
 _#checkoutCode: _#step & {
 	name: "Checkout source code"
 	uses: "actions/checkout@v3"


### PR DESCRIPTION
The patterns we define will roughly align with each workflow as a whole, so it make sense to just centralize the definition.