### PR TITLE
Only run Rust workflow on pushes to main branch

### DIFF
--- a/.github/cue/docs.cue
+++ b/.github/cue/docs.cue
@@ -3,6 +3,8 @@ package workflows
 docs: _#borsWorkflow & {
 	name: "docs"
 
+	on: push: branches: borsBranches
+
 	env: CARGO_TERM_COLOR: "always"
 
 	jobs: {

--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -3,6 +3,8 @@ package workflows
 githubActions: _#borsWorkflow & {
 	name: "github-actions"
 
+	on: push: branches: borsBranches
+
 	env: CARGO_TERM_COLOR: "always"
 
 	jobs: {

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -1,7 +1,11 @@
 package workflows
 
+import "list"
+
 rust: _#borsWorkflow & {
 	name: "rust"
+
+	on: push: branches: list.Concat([[defaultBranch], borsBranches])
 
 	env: {
 		CARGO_INCREMENTAL: 0

--- a/.github/cue/workflows.cue
+++ b/.github/cue/workflows.cue
@@ -1,9 +1,6 @@
 package workflows
 
-import (
-	"encoding/yaml"
-	"list"
-)
+import "encoding/yaml"
 
 import "json.schemastore.org/github"
 
@@ -48,15 +45,11 @@ _#borsWorkflow: _#pullRequestWorkflow & {
 	name: string
 	let workflowName = name
 
-	on: {
-		pull_request: branches: [defaultBranch]
-		push: branches: list.Concat([[defaultBranch], borsBranches])
-	}
+	on: pull_request: branches: [defaultBranch]
 
 	jobs: {
 		"bors": _#job & {
-			name: "bors needs met for \(workflowName)"
-			// TODO: ensure needs can't be empty
+			name:      "bors needs met for \(workflowName)"
 			needs:     github.#Workflow.#jobNeeds
 			"runs-on": defaultRunner
 			"if":      "always()"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,6 @@ name: docs
       - main
   push:
     branches:
-      - main
       - staging
       - trying
 env:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,7 +5,6 @@ name: github-actions
       - main
   push:
     branches:
-      - main
       - staging
       - trying
 env:


### PR DESCRIPTION
The other workflows are mostly check/format/lint items for the rest of the repo, so they should be just fine. I know the rust-cache option can pull from the target branch (main) when running on PRs, but I'm not sure the other tooling benefits from it being present in the main branch.