### PR TITLE
Force Windows to use BASH shell as well

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -65,6 +65,7 @@ rust: _#borsWorkflow & {
 		testStable: {
 			name: "test / stable"
 			needs: ["check", "format", "lint"]
+			defaults: run: shell: "bash"
 			strategy: {
 				"fail-fast": false
 				matrix: {

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -108,6 +108,9 @@ jobs:
       - check
       - format
       - lint
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is an experiment to see if caching improves within a BASH environment instead of PowerShell.