### PR TITLE
Ensure all YAML workflow files are cleared before generation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,14 @@
+# DO NOT EDIT THESE FILES!
+
+The GitHub Actions workflow YAML files in this directory are defined, validated,
+and generated using the [CUE][] (Configure, Unify, Execute) data constraint
+language. Editing the YAML directly will cause your changes to be rejected by
+CI, as the CUE and YAML files must be in sync.
+
+To generate these workflow YAML files, edit the CUE files under the sibling
+directory, and then run the following commands:
+
+    $ cd .github/cue/
+    $ cue cmd genworkflows
+
+[CUE]: https://cuelang.org/


### PR DESCRIPTION
This makes sure we don't have any accidental workflows lingering after a rename or manual editing. I've also added a README to draw attention to the fact that the YAML files should not be edited directly.

See:
- https://cuetorials.com/patterns/scripts-and-tasks/