### PR TITLE
Rename docs workflow to markdown

### DIFF
--- a/.github/cue/markdown.cue
+++ b/.github/cue/markdown.cue
@@ -1,7 +1,7 @@
 package workflows
 
-docs: _#borsWorkflow & {
-	name: "docs"
+markdown: _#borsWorkflow & {
+	name: "markdown"
 
 	on: push: branches: borsBranches
 
@@ -11,7 +11,7 @@ docs: _#borsWorkflow & {
 		changes: _#changes
 
 		markdownFormat: {
-			name: "markdown / format"
+			name: "format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
 			"if":      "${{ needs.changes.outputs.markdown == 'true' }}"

--- a/.github/cue/workflows.cue
+++ b/.github/cue/workflows.cue
@@ -11,16 +11,16 @@ workflows: [...{
 
 workflows: [
 	{
-		filename: "docs.yml"
-		workflow: docs
-	},
-	{
 		filename: "github-actions.yml"
 		workflow: githubActions
 	},
 	{
 		filename: "github-pages.yml"
 		workflow: githubPages
+	},
+	{
+		filename: "markdown.yml"
+		workflow: markdown
 	},
 	{
 		filename: "rust.yml"

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,4 +1,4 @@
-name: docs
+name: markdown
 "on":
   pull_request:
     branches:
@@ -46,7 +46,7 @@ jobs:
               - '**/Cargo.*'
               - .github/workflows/rust.yml
   markdownFormat:
-    name: markdown / format
+    name: format
     needs:
       - changes
     runs-on: ubuntu-latest
@@ -60,7 +60,7 @@ jobs:
           prettier_version: 2.8.8
           prettier_options: --check --color --prose-wrap always ${{ needs.changes.outputs.markdown_files }}
   bors:
-    name: bors needs met for docs
+    name: bors needs met for markdown
     needs:
       - markdownFormat
     runs-on: ubuntu-latest

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,6 @@
 status = [
-  "bors needs met for docs",
   "bors needs met for github-actions",
+  "bors needs met for markdown",
   "bors needs met for rust",
 ]
 #required_approvals = 1


### PR DESCRIPTION
The term "docs" is a bit overloaded since there is a lot of Rust project-specific docs references, and this also helps to match the file filters to make the connection more obvious.