### PR TITLE
Add a job to annotate common misspellings

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+builtin = clear,rare,usage,en-GB_to_en-US
+check-filenames =
+check-hidden =
+skip = ./.git,./.github/cue/cue.mod/pkg,./.jj,./target
+uri-ignore-words-list = *

--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -39,7 +39,7 @@ githubActions: _#borsWorkflow & {
 					run:                 "cue fmt"
 				},
 				{
-					name: "Check if CUE files were reformated"
+					name: "Check if CUE files were reformatted"
 					run: """
 						if git diff --quiet HEAD --; then
 						    echo "CUE files were already formatted; the working tree is clean."

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -1,7 +1,7 @@
 package workflows
 
-markdown: _#borsWorkflow & {
-	name: "markdown"
+wordsmith: _#borsWorkflow & {
+	name: "wordsmith"
 
 	on: push: branches: borsBranches
 
@@ -11,7 +11,7 @@ markdown: _#borsWorkflow & {
 		changes: _#changes
 
 		markdownFormat: {
-			name: "format"
+			name: "markdown / format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
 			"if":      "${{ needs.changes.outputs.markdown == 'true' }}"
@@ -25,8 +25,19 @@ markdown: _#borsWorkflow & {
 			]
 		}
 
+		spellcheck: {
+			name: "spellcheck"
+			needs: ["changes"]
+			"runs-on": defaultRunner
+			steps: [
+				_#checkoutCode,
+				_#codespell,
+			]
+		}
+
 		bors: needs: [
 			"markdownFormat",
+			"spellcheck",
 		]
 	}
 }

--- a/.github/cue/workflows.cue
+++ b/.github/cue/workflows.cue
@@ -19,12 +19,12 @@ workflows: [
 		workflow: githubPages
 	},
 	{
-		filename: "markdown.yml"
-		workflow: markdown
-	},
-	{
 		filename: "rust.yml"
 		workflow: rust
+	},
+	{
+		filename: "wordsmith.yml"
+		workflow: wordsmith
 	},
 ]
 
@@ -149,6 +149,11 @@ _#cacheRust: _#step & {
 _#cargoCheck: _#step & {
 	name: "Check packages and dependencies for errors"
 	run:  "cargo check --locked"
+}
+
+_#codespell: _#step & {
+	name: "Check common misspellings"
+	uses: "codespell-project/actions-codespell@22ff5a2e4b591290baf82d47c9feadac31c65441"
 }
 
 _#prettier: _#step & {

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Format CUE files
         working-directory: .github/cue
         run: cue fmt
-      - name: Check if CUE files were reformated
+      - name: Check if CUE files were reformatted
         run: |-
           if git diff --quiet HEAD --; then
               echo "CUE files were already formatted; the working tree is clean."

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -1,4 +1,4 @@
-name: markdown
+name: wordsmith
 "on":
   pull_request:
     branches:
@@ -46,7 +46,7 @@ jobs:
               - '**/Cargo.*'
               - .github/workflows/rust.yml
   markdownFormat:
-    name: format
+    name: markdown / format
     needs:
       - changes
     runs-on: ubuntu-latest
@@ -59,16 +59,37 @@ jobs:
         with:
           prettier_version: 2.8.8
           prettier_options: --check --color --prose-wrap always ${{ needs.changes.outputs.markdown_files }}
+  spellcheck:
+    name: spellcheck
+    needs:
+      - changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+      - name: Check common misspellings
+        uses: codespell-project/actions-codespell@22ff5a2e4b591290baf82d47c9feadac31c65441
   bors:
-    name: bors needs met for markdown
+    name: bors needs met for wordsmith
     needs:
       - markdownFormat
+      - spellcheck
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: 'Check status of job_id: markdownFormat'
         run: |-
           RESULT="${{ needs.markdownFormat.result }}";
+          if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
+              exit 0
+          else
+              echo "***"
+              echo "Error: The required job did not pass."
+              exit 1
+          fi
+      - name: 'Check status of job_id: spellcheck'
+        run: |-
+          RESULT="${{ needs.spellcheck.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ The format is based on [Keep a Changelog][1], and this project adheres to
 
 ## [Unreleased]
 
-[unreleased]: https://github.com/elasticdog/rustops-blueprint/tree/master
+[unreleased]: https://github.com/elasticdog/rustops-blueprint/tree/main

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
   "bors needs met for github-actions",
-  "bors needs met for markdown",
   "bors needs met for rust",
+  "bors needs met for wordsmith",
 ]
 #required_approvals = 1
 up_to_date_approvals = true


### PR DESCRIPTION
Note that there's now a codespell configuration file in the repo, so users can also run the tool locally and replicate what the job will do.

I've also renamed the workflow again since it's not just focused on Markdown anymore.

See:
- https://github.com/codespell-project/codespell/tree/master