### PR TITLE
Ensure that we run the doctests

### DIFF
--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -94,6 +94,10 @@ rust: _#borsWorkflow & {
 					name: "Run tests"
 					run:  "cargo nextest run --locked"
 				},
+				{
+					name: "Run doctests"
+					run:  "cargo test --locked --doc"
+				},
 			]
 		}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,6 +146,8 @@ jobs:
         run: cargo test --locked --no-run
       - name: Run tests
         run: cargo nextest run --locked
+      - name: Run doctests
+        run: cargo test --locked --doc
   checkMsrv:
     name: check / msrv
     needs:


### PR DESCRIPTION
Due to a limitation in how doctests are exposed in stable Rust, nextest does not actually run them by default. We unfortunately need an explicit step for the time being.

See:
- https://github.com/nextest-rs/nextest/issues/16