### PR TITLE
Supply Prettier with all Markdown files at once

### DIFF
--- a/xtask/src/fixup.rs
+++ b/xtask/src/fixup.rs
@@ -16,13 +16,18 @@ pub fn format_cue() -> Result<(), DynError> {
 
 pub fn format_markdown() -> Result<(), DynError> {
     let sh = Shell::new()?;
-    verbose_cd(&sh, project_root());
+    let root = project_root();
+    verbose_cd(&sh, &root);
 
     let markdown_files = find_markdown_files(sh.current_dir())?;
-    for file in markdown_files {
-        let relative_path = file.strip_prefix(project_root()).unwrap_or(&file);
-        cmd!(sh, "prettier --prose-wrap always --write {relative_path}").run()?;
-    }
+    let relative_paths: Vec<PathBuf> = markdown_files
+        .into_iter()
+        .filter_map(|path| path.strip_prefix(&root).ok().map(PathBuf::from))
+        .collect();
+
+    cmd!(sh, "prettier --prose-wrap always --write")
+        .args(&relative_paths)
+        .run()?;
 
     Ok(())
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -75,10 +75,9 @@ Usage: Run with `cargo xtask <task>`, eg. `cargo xtask fixup`.
 }
 
 pub fn project_root() -> PathBuf {
-    Path::new(&env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(1)
-        .unwrap()
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("Failed to find project root")
         .to_path_buf()
 }
 


### PR DESCRIPTION
Using xshell's command builder functions, we can supply all of the arguments at once rather than looping over the Markdown files and calling out to Prettier multiple times.