### PR TITLE
Switch from Bors-NG to GitHub-native merge queues

### DIFF
--- a/.github/cue/ci_tool.cue
+++ b/.github/cue/ci_tool.cue
@@ -10,7 +10,7 @@ import (
 
 // vendor a cue-imported version of the jsonschema that defines
 // github actions workflows into the main module's cue.mod/pkg
-command: importjsonschema: {
+command: "import-jsonschema": {
 	getJSONSchema: http.Get & {
 		// https://github.com/SchemaStore/schemastore/blob/master/src/schemas/json/github-workflow.json
 		_commit: "5ffe36662a8fcab3c32e8fbca39c5253809e6913"

--- a/.github/cue/github-actions.cue
+++ b/.github/cue/github-actions.cue
@@ -1,16 +1,14 @@
 package workflows
 
-githubActions: _#borsWorkflow & {
+githubActions: _#useMergeQueue & {
 	name: "github-actions"
-
-	on: push: branches: borsBranches
 
 	env: CARGO_TERM_COLOR: "always"
 
 	jobs: {
 		changes: _#detectFileChanges
 
-		cueVet: {
+		cue_vet: {
 			name: "cue / vet"
 			needs: ["changes"]
 			"runs-on": defaultRunner
@@ -26,9 +24,9 @@ githubActions: _#borsWorkflow & {
 			]
 		}
 
-		cueFormat: {
+		cue_format: {
 			name: "cue / format"
-			needs: ["cueVet"]
+			needs: ["cue_vet"]
 			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
@@ -55,9 +53,9 @@ githubActions: _#borsWorkflow & {
 			]
 		}
 
-		cueSynced: {
+		cue_synced: {
 			name: "cue / synced"
-			needs: ["cueVet"]
+			needs: ["cue_vet"]
 			"runs-on": defaultRunner
 			steps: [
 				_#checkoutCode,
@@ -84,9 +82,9 @@ githubActions: _#borsWorkflow & {
 			]
 		}
 
-		bors: needs: [
-			"cueFormat",
-			"cueSynced",
+		merge_queue: needs: [
+			"cue_format",
+			"cue_synced",
 		]
 	}
 }

--- a/.github/cue/rust.cue
+++ b/.github/cue/rust.cue
@@ -1,11 +1,9 @@
 package workflows
 
-import "list"
-
-rust: _#borsWorkflow & {
+rust: _#useMergeQueue & {
 	name: "rust"
 
-	on: push: branches: list.Concat([[defaultBranch], borsBranches])
+	on: push: branches: [defaultBranch]
 
 	env: {
 		CARGO_INCREMENTAL: 0
@@ -62,7 +60,7 @@ rust: _#borsWorkflow & {
 			]
 		}
 
-		testStable: {
+		test_stable: {
 			name: "test / stable"
 			needs: ["check", "format", "lint"]
 			defaults: run: shell: "bash"
@@ -96,7 +94,7 @@ rust: _#borsWorkflow & {
 		}
 
 		// Minimum Supported Rust Version
-		checkMsrv: {
+		check_msrv: {
 			name: "check / msrv"
 			needs: ["check", "format", "lint"]
 			"runs-on": defaultRunner
@@ -113,9 +111,9 @@ rust: _#borsWorkflow & {
 			]
 		}
 
-		bors: needs: [
-			"testStable",
-			"checkMsrv",
+		merge_queue: needs: [
+			"test_stable",
+			"check_msrv",
 		]
 	}
 }

--- a/.github/cue/wordsmith.cue
+++ b/.github/cue/wordsmith.cue
@@ -1,16 +1,14 @@
 package workflows
 
-wordsmith: _#borsWorkflow & {
+wordsmith: _#useMergeQueue & {
 	name: "wordsmith"
-
-	on: push: branches: borsBranches
 
 	env: CARGO_TERM_COLOR: "always"
 
 	jobs: {
 		changes: _#detectFileChanges
 
-		markdownFormat: {
+		markdown_format: {
 			name: "markdown / format"
 			needs: ["changes"]
 			"runs-on": defaultRunner
@@ -35,8 +33,8 @@ wordsmith: _#borsWorkflow & {
 			]
 		}
 
-		bors: needs: [
-			"markdownFormat",
+		merge_queue: needs: [
+			"markdown_format",
 			"spellcheck",
 		]
 	}

--- a/.github/cue/workflows.cue
+++ b/.github/cue/workflows.cue
@@ -29,8 +29,6 @@ workflows: [
 ]
 
 defaultBranch: "main"
-borsBranches: ["staging", "trying"]
-
 defaultRunner: "ubuntu-latest"
 
 _#pullRequestWorkflow: github.#Workflow & {
@@ -40,15 +38,17 @@ _#pullRequestWorkflow: github.#Workflow & {
 	}
 }
 
-// https://bors.tech/documentation/getting-started/
-_#borsWorkflow: _#pullRequestWorkflow & {
+_#useMergeQueue: _#pullRequestWorkflow & {
 	name: string
 	let workflowName = name
 
-	on: pull_request: branches: [defaultBranch]
+	on: {
+		pull_request: branches: [defaultBranch]
+		merge_group: types: ["checks_requested"]
+	}
 
-	jobs: bors: _#job & {
-		name:      "bors needs met for \(workflowName)"
+	jobs: merge_queue: _#job & {
+		name:      "\(workflowName) workflow ready"
 		needs:     github.#Workflow.#jobNeeds
 		"runs-on": defaultRunner
 		if:        "always()"

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -5,10 +5,9 @@ name: github-actions
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
+    types:
+      - checks_requested
 env:
   CARGO_TERM_COLOR: always
 concurrency:
@@ -47,7 +46,7 @@ jobs:
               - '**/*.rs'
               - '**/Cargo.*'
               - .github/workflows/rust.yml
-  cueVet:
+  cue_vet:
     name: cue / vet
     needs:
       - changes
@@ -63,10 +62,10 @@ jobs:
       - name: Validate CUE files
         working-directory: .github/cue
         run: cue vet -c
-  cueFormat:
+  cue_format:
     name: cue / format
     needs:
-      - cueVet
+      - cue_vet
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -89,10 +88,10 @@ jobs:
               echo "Run 'cargo xtask fixup.github-actions' locally to format the CUE files."
               exit 1
           fi
-  cueSynced:
+  cue_synced:
     name: cue / synced
     needs:
-      - cueVet
+      - cue_vet
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
@@ -115,17 +114,17 @@ jobs:
               echo "Run 'cargo xtask fixup.github-actions' locally to regenerate the YAML from CUE."
               exit 1
           fi
-  bors:
-    name: bors needs met for github-actions
+  merge_queue:
+    name: github-actions workflow ready
     needs:
-      - cueFormat
-      - cueSynced
+      - cue_format
+      - cue_synced
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: 'Check status of job_id: cueFormat'
+      - name: 'Check status of job_id: cue_format'
         run: |-
-          RESULT="${{ needs.cueFormat.result }}";
+          RESULT="${{ needs.cue_format.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else
@@ -133,9 +132,9 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: cueSynced'
+      - name: 'Check status of job_id: cue_synced'
         run: |-
-          RESULT="${{ needs.cueSynced.result }}";
+          RESULT="${{ needs.cue_synced.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,11 +5,12 @@ name: rust
   pull_request:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main
-      - staging
-      - trying
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always
@@ -111,7 +112,7 @@ jobs:
           shared-key: workflow
       - name: Check lints
         run: cargo clippy --no-deps -- -D warnings
-  testStable:
+  test_stable:
     name: test / stable
     needs:
       - check
@@ -150,7 +151,7 @@ jobs:
         run: cargo nextest run --locked
       - name: Run doctests
         run: cargo test --locked --doc
-  checkMsrv:
+  check_msrv:
     name: check / msrv
     needs:
       - check
@@ -174,17 +175,17 @@ jobs:
           shared-key: workflow
       - name: Check packages and dependencies for errors
         run: cargo check --locked
-  bors:
-    name: bors needs met for rust
+  merge_queue:
+    name: rust workflow ready
     needs:
-      - testStable
-      - checkMsrv
+      - test_stable
+      - check_msrv
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: 'Check status of job_id: testStable'
+      - name: 'Check status of job_id: test_stable'
         run: |-
-          RESULT="${{ needs.testStable.result }}";
+          RESULT="${{ needs.test_stable.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else
@@ -192,9 +193,9 @@ jobs:
               echo "Error: The required job did not pass."
               exit 1
           fi
-      - name: 'Check status of job_id: checkMsrv'
+      - name: 'Check status of job_id: check_msrv'
         run: |-
-          RESULT="${{ needs.checkMsrv.result }}";
+          RESULT="${{ needs.check_msrv.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/.github/workflows/wordsmith.yml
+++ b/.github/workflows/wordsmith.yml
@@ -5,10 +5,9 @@ name: wordsmith
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - staging
-      - trying
+  merge_group:
+    types:
+      - checks_requested
 env:
   CARGO_TERM_COLOR: always
 concurrency:
@@ -47,7 +46,7 @@ jobs:
               - '**/*.rs'
               - '**/Cargo.*'
               - .github/workflows/rust.yml
-  markdownFormat:
+  markdown_format:
     name: markdown / format
     needs:
       - changes
@@ -71,17 +70,17 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Check common misspellings
         uses: codespell-project/actions-codespell@22ff5a2e4b591290baf82d47c9feadac31c65441
-  bors:
-    name: bors needs met for wordsmith
+  merge_queue:
+    name: wordsmith workflow ready
     needs:
-      - markdownFormat
+      - markdown_format
       - spellcheck
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - name: 'Check status of job_id: markdownFormat'
+      - name: 'Check status of job_id: markdown_format'
         run: |-
-          RESULT="${{ needs.markdownFormat.result }}";
+          RESULT="${{ needs.markdown_format.result }}";
           if [[ $RESULT == "success" || $RESULT == "skipped" ]]; then
               exit 0
           else

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
 # Contributing
 
-We use [bors-ng](https://bors.tech) to enforce the
+We use GitHub [merge queues][] to enforce the
 [not rocket science](https://graydon2.dreamwidth.org/1597.html) rule.
+
+[merge queues]:
+  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,0 @@
-status = [
-  "bors needs met for github-actions",
-  "bors needs met for rust",
-  "bors needs met for wordsmith",
-]
-#required_approvals = 1
-up_to_date_approvals = true


### PR DESCRIPTION
The @bors[bot] [posted](https://github.com/elasticdog/rustops-blueprint/pull/55#issuecomment-1531717997) in a pull request today:

> The publicly hosted instance of bors-ng is deprecated and will go away soon.

GitHub merge queues are still in public beta, but what better time to kick the tires!? I've already revoked access to the repository for the bors app and will have to adjust some of the branch protection rules.

See:
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
- https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request-with-a-merge-queue
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group